### PR TITLE
refactor: 重构 decompress 库代码结构

### DIFF
--- a/decompress/base_decompressor.py
+++ b/decompress/base_decompressor.py
@@ -3,7 +3,12 @@
 解压器基类模块
 """
 from abc import ABC, abstractmethod
+from os import access, R_OK, W_OK, X_OK
+from os.path import realpath, exists, isdir
 from typing import NoReturn
+
+from decompress.exceptions import CompressedFileNotFoundError, CompressedFilePermissionDenyError, \
+    OutputDirNotFoundError, OutputNotDirError, OutputDirPermissionDenyError
 
 
 class BaseDecompressor(ABC):
@@ -20,15 +25,51 @@ class BaseDecompressor(ABC):
         """
         pass
 
-    @staticmethod
     @abstractmethod
-    def _verify(path: str, max_size: int, max_count: int) -> NoReturn:
+    def _verify(self, path: str, output_dir: str, max_size: int, max_count: int) -> NoReturn:
         """
-        对压缩文件进行检验，通过设置解压后允许的文件大小上限和文件数量上限，防止压缩炸弹攻击
+        对压缩文件进行检验
         :param path: 压缩文件路径，可以是相对路径或绝对路径
+        :param output_dir: 压缩文件输出目录路径，可以是相对路径或绝对路径
         :param max_size: 压缩文件解压后，得到文件大小的上限
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
         pass
 
+    @staticmethod
+    def _verify_decompressed_file(path: str) -> NoReturn:
+        """
+        校验压缩文件
+        :param path: 压缩文件路径，可以是相对路径或绝对路径
+        :return: None
+        """
+        path = realpath(path)
+        # 判断压缩文件是否存在
+        if not exists(path):
+            raise CompressedFileNotFoundError(path)
+        # 判断当前用户对压缩文件是否有读权限
+        if not access(path, R_OK):
+            raise CompressedFilePermissionDenyError(path)
+        # TODO
+        # 1. 校验压缩文件中是否包含 / 或者 ..
+
+    @staticmethod
+    def _verify_output_dir(path: str) -> NoReturn:
+        """
+        校验输出目录
+        :param path: 压缩文件输出目录路径，可以是相对路径或绝对路径
+        :return: None
+        """
+        path = realpath(path)
+        # 判断输出目录是否存在
+        if not exists(path):
+            raise OutputDirNotFoundError(path)
+        # 判断是否是目录
+        if not isdir(path):
+            raise OutputNotDirError(path)
+        # 判断目录是否有写执行权限，没有则不能解压到该目录
+        if not access(path, W_OK | X_OK):
+            raise OutputDirPermissionDenyError(path)
+        # TODO
+        # 1. 校验压缩文件解压输出路径是否有足够的空间

--- a/decompress/decompressor.py
+++ b/decompress/decompressor.py
@@ -2,17 +2,13 @@
 """
 解压器工厂模块
 """
-import os
-import tarfile
-import zipfile
-from typing import Optional, NoReturn
+from os.path import dirname, realpath
+from tarfile import is_tarfile
+from typing import Optional, NoReturn, Union
+from zipfile import is_zipfile
 
 from decompress.exceptions import (
-    CompressedFileNotFoundError,
-    CompressedFilePermissionDenyError,
-    OutputDirNotFoundError,
-    OutputNotDirError,
-    OutputDirPermissionDenyError, UnsupportedTypeError,
+    UnsupportedTypeError,
 )
 from decompress.tarball_decompressor import TarballDecompressor
 from decompress.zip_decompressor import ZipDecompressor
@@ -35,65 +31,23 @@ class Decompressor:
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
-        # 获取压缩文件的绝对路径，并进行校验
-        decompressed_file_path = os.path.realpath(decompressed_file_path)
-        self._verify_decompressed_file(decompressed_file_path)
         # 当没有指定解压到某个路径时，默认解压至当前路径
         if output_dir is None:
-            output_dir = '.'
-        # 获取输出目录的绝对路径，并进行校验
-        output_dir = os.path.realpath(output_dir)
-        self._verify_output_dir(output_dir)
+            output_dir = dirname(realpath(decompressed_file_path))
         # 根据压缩文件的压缩格式，获取对应的解压器类，并进行解压
         decompressor = self._get_decompressor(decompressed_file_path)
         decompressor.decompress(decompressed_file_path, output_dir, max_size, max_count)
 
     @classmethod
-    def _get_decompressor(cls, path: str) -> Optional[TarballDecompressor, ZipDecompressor]:
+    def _get_decompressor(cls, path: str) -> Union[TarballDecompressor, ZipDecompressor]:
         """
         解压器工厂方法，根据压缩文件的压缩格式，返回对应的压缩器类
         :param path: 压缩文件路径，可以是相对路径或绝对路径
         :return: 对应的压缩器类
         """
-        if tarfile.is_tarfile(path):
+        if is_tarfile(path):
             return TarballDecompressor()
-        elif zipfile.is_zipfile(path):
+        elif is_zipfile(path):
             return ZipDecompressor()
         else:
             raise UnsupportedTypeError(path)
-
-    @staticmethod
-    def _verify_decompressed_file(path: str) -> NoReturn:
-        """
-        校验压缩文件
-        :param path: 压缩文件路径，可以是相对路径或绝对路径
-        :return: None
-        """
-        path = os.path.realpath(path)
-        # 判断压缩文件是否存在
-        if not os.path.exists(path):
-            raise CompressedFileNotFoundError(path)
-        # 判断当前用户对压缩文件是否有读权限
-        if not os.access(path, os.R_OK):
-            raise CompressedFilePermissionDenyError(path)
-        # TODO
-        # 1. 校验压缩文件中是否包含 / 或者 ..
-
-    @staticmethod
-    def _verify_output_dir(path: str) -> NoReturn:
-        """
-        校验输出目录
-        :param path: 压缩文件输出目录路径，可以是相对路径或绝对路径
-        :return: None
-        """
-        # 判断输出目录是否存在
-        if not os.path.exists(path):
-            raise OutputDirNotFoundError(path)
-        # 判断是否是目录
-        if not os.path.isdir(path):
-            raise OutputNotDirError(path)
-        # 判断目录是否有读写执行权限，没有则不能解压到该目录
-        if not os.access(path, os.R_OK | os.W_OK | os.X_OK):
-            raise OutputDirPermissionDenyError(path)
-        # TODO
-        # 1. 校验压缩文件解压输出路径是否有足够的空间

--- a/decompress/tarball_decompressor.py
+++ b/decompress/tarball_decompressor.py
@@ -20,19 +20,24 @@ class TarballDecompressor(BaseDecompressor):
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
-        self._verify(path, max_size, max_count)
+        self._verify(path, output_dir, max_size, max_count)
         with tarfile.open(path) as tf:
             tf.extractall(path=output_dir)
 
-    @staticmethod
-    def _verify(path: str, max_size: int, max_count: int) -> NoReturn:
+    def _verify(self, path: str, output_dir: str, max_size: int, max_count: int) -> NoReturn:
         """
-        对压缩文件进行检验，通过设置解压后文件大小上限和文件数量上限，防止压缩炸弹攻击
+        对压缩文件进行检验
         :param path: 压缩文件路径，可以是相对路径或绝对路径
+        :param output_dir: 压缩文件输出目录路径，可以是相对路径或绝对路径
         :param max_size: 压缩文件解压后，得到文件大小的上限
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
+        # 对压缩文件进行基本的校验
+        self._verify_decompressed_file(path)
+        # 对输出目录进行基本的校验
+        self._verify_output_dir(output_dir)
+        # 校验压缩文件的大小和文件数量是否符合要求
         with tarfile.open(path) as tf:
             total_size = 0
             for _ in range(max_count + 1):

--- a/decompress/zip_decompressor.py
+++ b/decompress/zip_decompressor.py
@@ -20,19 +20,24 @@ class ZipDecompressor(BaseDecompressor):
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
-        self._verify(path, max_size, max_count)
+        self._verify(path, output_dir, max_size, max_count)
         with ZipFile(path) as zf:
             zf.extractall(path=output_dir)
 
-    @staticmethod
-    def _verify(path: str, max_size: int, max_count: int) -> NoReturn:
+    def _verify(self, path: str, output_dir: str, max_size: int, max_count: int) -> NoReturn:
         """
-        对压缩文件进行检验，通过设置解压后文件大小上限和文件数量上限，防止压缩炸弹攻击
+        对压缩文件进行检验
         :param path: 压缩文件路径，可以是相对路径或绝对路径
+        :param output_dir: 压缩文件输出目录路径，可以是相对路径或绝对路径
         :param max_size: 压缩文件解压后，得到文件大小的上限
         :param max_count: 压缩文件解压后，得到文件数量的上限
         :return: None
         """
+        # 对压缩文件进行基本的校验
+        self._verify_decompressed_file(path)
+        # 对输出目录进行基本的校验
+        self._verify_output_dir(output_dir)
+        # 校验压缩文件的大小和文件数量是否符合要求
         with ZipFile(path) as zf:
             total_size = 0
             members = zf.infolist()


### PR DESCRIPTION
1. 重构 decompress 库代码结构，将在工厂类 `Decompressor` 中的校验方法移动到解压器基类 `BaseDecompressor` 中，由解压器子类去调用校验方法。
2. 修改导入形式。
3. 修改类型注解和方法文档。